### PR TITLE
Add CNAME to lisp.com.br

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+lisp.com.br


### PR DESCRIPTION
Pronto! Em breve poderemos acessar nosso site cheiroso por um
fácil e memorável domínio. Por enquanto estamos resolvendo
um pequeno problema relacionado aos nameservers de DNS
do registro.br, eles estão em manuntenção. Mas
assim que estiver tudo configurado irei fazer merge desse PR.

:) Agradecimentos ao Helio Cordeiro que havia posse do domínio
desde 2015 e está reservado até 2020 para nosso uso! (se ele permitir)


Obrigado aí pessoal.