### PR TITLE
Fix Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ shell:
 %.html: %.org
 	@printf $(STATUS_PREFIX); echo "COMPILING: $< -> $*.html"
 	@$(DOCKER_RUN) $(DOCKER_IMG) $< $(EMACS_FLAGS) -f org-html-export-to-html
-	@$(DOCKER_RUN) --entrypoint=/bin/chown $(DOCKER_IMG) $(USER) "$*.org"
+	@$(DOCKER_RUN) --entrypoint=/bin/chown $(DOCKER_IMG) $(USER) "$*.html"
 
 clean:
 	rm -rf *.html


### PR DESCRIPTION
Chown should own the .html files, not .org.
Because Docker run as root by default, so the files will be created
as root as well. This behavior is not intended.