### PR TITLE
Integra glossário, atualiza 'aprendizado.org' e conserta link do artigo de 'notação polonesa'.

### DIFF
--- a/index.org
+++ b/index.org
@@ -3,7 +3,7 @@
 #+AUTHOR: Manoel Vilela, Lucas Vieira, Hélio Cordeiro
 #+DATE: <2018-02-10 Sat>
 #+TITLE: Common Lisp Brasil
-#+LANGUAGE: bt-br
+#+LANGUAGE: pt-br
 #+LATEX_HEADER: \usepackage[]{babel}
 #+OPTIONS: toc:nil
 
@@ -26,10 +26,11 @@ repositório desta página]].
 
 - [[file:appendix.html][Apêndice]]
 - [[http://lisp.com.br/archive/][Arquivos]]
-- [[http://lisp.com.br/cl-cookbook][The Common Lisp Cookbook (PT-BR) (em progresso)]]
+- [[dictionary.html][Glossário de termos]]
 - [[file:projects.html][Projetos]]
 - [[file:rules.html][Regras]]
-
+- [[http://lisp.com.br/cl-cookbook][The Common Lisp Cookbook (PT-BR) (em progresso)]]
+  
 * Conceitos e Fundamentos
 #+INCLUDE: subsections/index/conceitos-e-fundamentos.org :only-contents t
 

--- a/index.org
+++ b/index.org
@@ -3,7 +3,7 @@
 #+AUTHOR: Manoel Vilela, Lucas Vieira, Hélio Cordeiro
 #+DATE: <2018-02-10 Sat>
 #+TITLE: Common Lisp Brasil
-#+LANGUAGE: pt-br
+#+LANGUAGE: bt-br #isso não é um erro.
 #+LATEX_HEADER: \usepackage[]{babel}
 #+OPTIONS: toc:nil
 
@@ -25,11 +25,11 @@ repositório desta página]].
 * Sitemap
 
 - [[file:appendix.html][Apêndice]]
-- [[http://lisp.com.br/archive/][Arquivos]]
-- [[dictionary.html][Glossário de termos]]
+- [[https://lisp.com.br/archive/][Arquivos]]
+- [[https://lisp.com.br/dictionary.html][Glossário de termos]]
 - [[file:projects.html][Projetos]]
 - [[file:rules.html][Regras]]
-- [[http://lisp.com.br/cl-cookbook][The Common Lisp Cookbook (PT-BR) (em progresso)]]
+- [[https://lisp.com.br/cl-cookbook][The Common Lisp Cookbook (PT-BR) (em progresso)]]
   
 * Conceitos e Fundamentos
 #+INCLUDE: subsections/index/conceitos-e-fundamentos.org :only-contents t

--- a/subsections/index/aprendizado.org
+++ b/subsections/index/aprendizado.org
@@ -22,12 +22,20 @@ interativas como Lisp e Python. A propósito, o conceito foi
 inicialmente feito justamente em Lisp!
 
 * Livros
+# Os livros físicos devem conter link para compra em lojas no Brasil. Links de compras em outros países não serão aceitos.
 
 - Common Lisp: A Gentle Introduction to Symbolic Computation, por David S. Touretsky
-  - [Amazon] [[https://www.amazon.com.br/Common-LISP-Introduction-Computation-Engineering-ebook/dp/B00IZUEG1G/][Livro físico]]
+  - [[https://www.amazon.com.br/Common-LISP-Introduction-Computation-Engineering-ebook/dp/B00IZUEG1G/][Livro físico]] [/Amazon/]
   - [[https://www.cs.cmu.edu/~dst/LispBook/][Versão online]]
-- [Amazon] [[https://www.amazon.com.br/Land-Lisp-Learn-Program-Game-ebook/dp/B004AE3P4K/][Land of Lisp: Learn to Program in Lisp, One Game at a Time!]], por Conrad Barski
-- [Amazon] [[https://www.amazon.com.br/Common-Lisp-Recipes-Problem-Solution-Approach-ebook/dp/B01JFTONBS/][Common Lisp Recipes: A Problem-Solution Approach]], por Edmund Weitz
-- Practical Common Lisp, por Peter Seibel
-  - [Amazon] [[https://www.amazon.com.br/Practical-Common-Lisp-Peter-Seibel/dp/1590592395][Livro físico]]
+
+- [[https://www.amazon.com.br/Common-Lisp-Recipes-Problem-Solution-Approach-ebook/dp/B01JFTONBS/][Common Lisp Recipes: A Problem-Solution Approach]], por Edmund Weitz. [/Amazon/]
+
+- Practical Common Lisp, por Peter Seibel.
+  - [[https://www.amazon.com.br/Practical-Common-Lisp-Peter-Seibel/dp/1590592395][Livro físico]] [/Amazon/]
   - [[http://www.gigamonkeys.com/book/][Versão online]]
+
+- [[https://www.cs.cmu.edu/Groups/AI/html/cltl/clm/clm.html][Common Lisp the Language, 2nd Edition]], por Guy L. Steele Jr. [/Online/]
+
+- [[https://www.amazon.com.br/Land-Lisp-Learn-Program-Game-ebook/dp/B004AE3P4K/][Land of Lisp: Learn to Program in Lisp, One Game at a Time!]], por Conrad Barski. [/Amazon/]
+
+- [[https://lispcookbook.github.io/cl-cookbook/][The Common Lisp Cookbook]] (/inglês/). [/Online/]

--- a/subsections/index/conceitos-e-fundamentos.org
+++ b/subsections/index/conceitos-e-fundamentos.org
@@ -15,7 +15,7 @@ valores e/ou a procedimentos. Na linguagens da família Lisp, há a
 peculiaridade de existir uma linha muito tênue de separação entre
 dados e procedimentos no código-fonte. Na realidade, é possível
 produzir código a partir de dados e vice-versa! Uma das
-características fortes da linguagem é o uso da [[https://pt.wikipedia.org/wiki/Nota%25C3%25A7%25C3%25A3o_polonesa][notação polonesa]], que
+características fortes da linguagem é o uso da [[https://pt.wikipedia.org/wiki/Nota%C3%A7%C3%A3o_polonesa][notação polonesa]] que
 simplifica a sintaxe da linguagem, de forma a previnir ambiguidades:
 operações e operandos são denotados de forma explícita, em sua ordem
 de precedência, no uso de listas.


### PR DESCRIPTION
Modificado o arquivo 'aprendizado.org', adicionando links para outros livros, organizando-os em ordem alfabética. Também modifiquei os prefixos, que antes estavam do lado esquerdo, porém coloquei no lado direito, para melhor visualização.

Consertado o link quebrado do 'notação polonesa', de acordo com a issue #42