### PR TITLE
Remove canal que não existe mais

### DIFF
--- a/index.org
+++ b/index.org
@@ -12,7 +12,6 @@ Olá! Seja-bem vindo ao grupo de estudos
 e projetos do Common Lisp Brasil!
 
 - Grupo *oficial* do Telegram: [[https://telegram.me/commonlispbr][Common Lisp Brasil]].
-- Canal *oficial* no Telegram: [[https://telegram.me/commonlispbrchan][Common Lisp Brasil Chan]]
 - Nosso canal de livros de Computação e Lisp: [[https://telegram.me/commonlispbr_livros][Common Lisp Brasil Livros]].
 
 Os dados a seguir podem estar incompletos ou conter erros. Proceda com


### PR DESCRIPTION
Canal foi deletado anteriormente por falta de atividade e propósito. Agora deve também sumir da página principal.