### PR TITLE
implement minification in in the makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ DOCKER_RUN          := docker run  -w /tmp \
 	                               -v $(shell pwd):/tmp \
                                    --rm \
                                    -t
+MINIFY              := $(DOCKER_RUN) --entrypoint="/usr/bin/minify" $(MINIFY_IMG)
 
 STATUS_PREFIX       := "\033[1;32m[+]\033[0m "
 
@@ -30,15 +31,15 @@ setup:
 	@$(DOCKER_RUN) $(DOCKER_IMG) $< $(EMACS_FLAGS) -f org-html-export-to-html
 	@mv $*.html $(STATIC_FILES_FOLDER)/$*.html
 	@printf $(STATUS_PREFIX); echo "MINIFYING: $*.html"
-	@$(DOCKER_RUN) --entrypoint="" $(MINIFY_IMG) sh -c 'minify $(STATIC_FILES_FOLDER)/$*.html -o $(STATIC_FILES_FOLDER)/$*.html'
+	@$(MINIFY) $(STATIC_FILES_FOLDER)/$*.html -o $(STATIC_FILES_FOLDER)/$*.html
 
 minify:
 	@printf $(STATUS_PREFIX); echo "MINIFYING AND BUNDLING CSS FILES"
-	@$(DOCKER_RUN) --entrypoint="" $(MINIFY_IMG) sh -c 'minify --bundle org-theme/dist/long/bundle.css css/syntax.css -o $(STATIC_FILES_FOLDER)/long.css'
-	@$(DOCKER_RUN) --entrypoint="" $(MINIFY_IMG) sh -c 'minify --bundle org-theme/dist/short/bundle.css css/syntax.css -o $(STATIC_FILES_FOLDER)/short.css'
+	@$(MINIFY) --bundle org-theme/dist/long/bundle.css css/syntax.css -o $(STATIC_FILES_FOLDER)/long.css
+	@$(MINIFY) --bundle org-theme/dist/short/bundle.css css/syntax.css -o $(STATIC_FILES_FOLDER)/short.css
 	@printf $(STATUS_PREFIX); echo "MINIFYING JS FILES"
-	@$(DOCKER_RUN) --entrypoint="" $(MINIFY_IMG) sh -c 'minify --bundle org-theme/dist/long/bundle.js -o $(STATIC_FILES_FOLDER)/long.js'
-	@$(DOCKER_RUN) --entrypoint="" $(MINIFY_IMG) sh -c 'minify --bundle org-theme/dist/long/bundle.js -o $(STATIC_FILES_FOLDER)/short.js'
+	@$(MINIFY) --bundle org-theme/dist/long/bundle.js -o $(STATIC_FILES_FOLDER)/long.js
+	@$(MINIFY) --bundle org-theme/dist/long/bundle.js -o $(STATIC_FILES_FOLDER)/short.js
 
 server:
 	python3 -m http.server 8000 --directory $(STATIC_FILES_FOLDER)

--- a/Makefile
+++ b/Makefile
@@ -1,44 +1,47 @@
-EMACS_INIT  := /root/.emacs.d/init.el
-EMACS_LOAD  := -l $(EMACS_INIT)
-EMACS_FLAGS := --batch --kill $(EMACS_LOAD)
-ORG_FILES   := $(wildcard *.org)
-HTML_FILES  := $(patsubst %.org, %.html, $(ORG_FILES))
-DOCKER_IMG  := commonlispbr/emacs
-USER        := $(shell id -u):$(shell id -g)
-DOCKER_RUN  := docker run  -w /tmp \
-	                       -v $(shell pwd):/tmp \
-                           --rm \
-                           -t
-STATUS_PREFIX    := "\033[1;32m[+]\033[0m "
-ATTENTION_PREFIX := "\033[1;36m[!]\033[0m "
+EMACS_INIT          := /root/.emacs.d/init.el
+EMACS_LOAD          := -l $(EMACS_INIT)
+EMACS_FLAGS         := --batch --kill $(EMACS_LOAD)
+ORG_FILES           := $(wildcard *.org)
+HTML_FILES          := $(patsubst %.org, %.html, $(ORG_FILES))
+STATIC_FILES_FOLDER := static/
+DOCKER_IMG          := commonlispbr/emacs
+MINIFY_IMG          := tdewolff/minify
+USER                := $(shell id -u):$(shell id -g)
+DOCKER_RUN          := docker run  -w /tmp \
+	                               -v $(shell pwd):/tmp \
+                                   --rm \
+                                   -t
+
+STATUS_PREFIX       := "\033[1;32m[+]\033[0m "
 
 .PHONY: clean shell
 
-all: $(HTML_FILES) copy
+all: setup $(HTML_FILES) minify
 
 shell:
 	$(DOCKER_RUN) -i --entrypoint=/bin/zsh $(DOCKER_IMG)
 
+setup:
+	@printf $(STATUS_PREFIX); echo "CREATING STATIC FOLDER: $(STATIC_FILES_FOLDER)"
+	@mkdir -p static
+
 %.html: %.org
 	@printf $(STATUS_PREFIX); echo "COMPILING: $< -> $*.html"
 	@$(DOCKER_RUN) $(DOCKER_IMG) $< $(EMACS_FLAGS) -f org-html-export-to-html
-	@$(DOCKER_RUN) --entrypoint=/bin/chown $(DOCKER_IMG) $(USER) "$*.html"
+	@mv $*.html $(STATIC_FILES_FOLDER)/$*.html
+	@printf $(STATUS_PREFIX); echo "MINIFYING: $*.html"
+	@$(DOCKER_RUN) --entrypoint="" $(MINIFY_IMG) sh -c 'minify $(STATIC_FILES_FOLDER)/$*.html -o $(STATIC_FILES_FOLDER)/$*.html'
 
-copy:
-	@mkdir -p static
-	@find . \
-	      "(" -name "*.html" -o -name "*.css" -o -name "*.js" ")" \
-	      -not -path "./static/*" \
-	      -not -path "./.github/*" \
-	      -exec cp {} static \;
-	@find . \
-	      -name "*.html" \
-	      -not -path "./static/*" \
-	      -not -path "./.github/*" \
-	      -exec mv {} static \;
+minify:
+	@printf $(STATUS_PREFIX); echo "MINIFYING AND BUNDLING CSS FILES"
+	@$(DOCKER_RUN) --entrypoint="" $(MINIFY_IMG) sh -c 'minify --bundle org-theme/dist/long/bundle.css css/syntax.css -o $(STATIC_FILES_FOLDER)/long.css'
+	@$(DOCKER_RUN) --entrypoint="" $(MINIFY_IMG) sh -c 'minify --bundle org-theme/dist/short/bundle.css css/syntax.css -o $(STATIC_FILES_FOLDER)/short.css'
+	@printf $(STATUS_PREFIX); echo "MINIFYING JS FILES"
+	@$(DOCKER_RUN) --entrypoint="" $(MINIFY_IMG) sh -c 'minify --bundle org-theme/dist/long/bundle.js -o $(STATIC_FILES_FOLDER)/long.js'
+	@$(DOCKER_RUN) --entrypoint="" $(MINIFY_IMG) sh -c 'minify --bundle org-theme/dist/long/bundle.js -o $(STATIC_FILES_FOLDER)/short.js'
 
 server:
-	python3 -m http.server 8000 --directory ./static
+	python3 -m http.server 8000 --directory $(STATIC_FILES_FOLDER)
 
 clean:
-	rm -rf ./static
+	rm -rf $(STATIC_FILES_FOLDER)

--- a/org-theme/setup/long.setup
+++ b/org-theme/setup/long.setup
@@ -20,6 +20,5 @@
 # I recommend you to generate your own css/js files by forking, cloning and customizing the file
 # theme.json before building it.
 #
-#+HTML_HEAD: <link rel="stylesheet" type="text/css" href="bundle.css"/>
-#+HTML_HEAD: <link rel="stylesheet" type="text/css" href="syntax.css" />
-#+HTML_HEAD: <script src="bundle.js" type="text/javascript" ></script>
+#+HTML_HEAD: <link rel="stylesheet" type="text/css" href="long.css"/>
+#+HTML_HEAD: <script src="long.js" type="text/javascript" ></script>

--- a/org-theme/setup/short.setup
+++ b/org-theme/setup/short.setup
@@ -17,6 +17,5 @@
 # theme.json before building it.
 #
 #
-#+HTML_HEAD: <link rel="stylesheet" type="text/css" href="bundle.css"/>
-#+HTML_HEAD: <link rel="stylesheet" type="text/css" href="syntax.css" />
-#+HTML_HEAD: <script src="bundle.js" type="text/javascript" ></script>
+#+HTML_HEAD: <link rel="stylesheet" type="text/css" href="short.css"/>
+#+HTML_HEAD: <script src="short.js" type="text/javascript" ></script>


### PR DESCRIPTION
Fixes #63 

This reduces the total size of the static assets from 77.39kB to 44.56kB (about 57% of the original size).

Also, as we are bundling together the CSS files, we reduce the number of requests by one, which should be marginally faster.